### PR TITLE
100vh height on profile was causing scaling issue

### DIFF
--- a/src/stylesheets/about_me.scss
+++ b/src/stylesheets/about_me.scss
@@ -194,11 +194,6 @@
 
 @media screen and (min-width: 600px) and (orientation: landscape) {
   .about-me-card {
-    padding: 0;
-    .profile {
-      height: 100vh;
-    }
-
     h1 {
       font-size: var(--font-size-900);
     }


### PR DESCRIPTION
I set .profile heigh to 100vh to ensure it always took 100% of the available height. However it caused issues when the user began to zoom in, causing it to partially be cut off. So I switched to 100% to make sure all the information is displayed properly. What is even the point of vh and vw...